### PR TITLE
Rename module to github.com/freifunkMUC/pg-events

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/freifunkMUC/pg-events/pkg/pgevents"
+
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 	"github.com/pkg/errors"
-	"github.com/place1/pg-events/pkg/pgevents"
 	"github.com/sirupsen/logrus"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/place1/pg-events
+module github.com/freifunkMUC/pg-events
 
 go 1.13
 


### PR DESCRIPTION
This will allow us to remove the `replace` directive in wg-access-server's go.mod and reference it directly.
See https://github.com/freifunkMUC/wg-access-server/pull/120